### PR TITLE
[bugfix] Fix the disappearing healthbar

### DIFF
--- a/core/src/com/league/game/Handlers/UDPStateHandler.java
+++ b/core/src/com/league/game/Handlers/UDPStateHandler.java
@@ -17,6 +17,7 @@ public class UDPStateHandler {
         Map<String, HeroGameEntity> newPlayersOnClient = new HashMap<String, HeroGameEntity>();
         for (SerializableHeroEntity serializableHeroEntity : gameState.getConnectedPlayers().values()) {
             HeroGameEntity heroGameEntity = new HeroGameEntity();
+            heroGameEntity.setHealth(serializableHeroEntity.getHealth());
             heroGameEntity.setHeroName(serializableHeroEntity.getHeroName());
             heroGameEntity.setHeroId(serializableHeroEntity.getId());
             heroGameEntity.setXPos(serializableHeroEntity.getXPos());

--- a/core/src/com/league/game/models/LivingGameEntity.java
+++ b/core/src/com/league/game/models/LivingGameEntity.java
@@ -18,7 +18,22 @@ public class LivingGameEntity extends GameEntity{
     @Override
     public void draw(SpriteBatch spriteBatch) {
         spriteBatch.draw(this.getEntityImage(), this.getXPos(), this.getYPos(), this.getWidth(), this.getHeight());
-        spriteBatch.draw(healthBarImage, this.getXPos(), this.getYPos() + (this.getHeight() * 1.02f), this.getWidth() * relu(this.health / MAX_HEALTH), this.getHeight()/20);
+        if (healthBarImage == null) {
+            System.err.println("HealthBarImage not loaded!");
+            return;
+        }
+        System.out.println("this.getWidth: " + this.getWidth());
+        System.out.println("this.health: " + this.health);
+        System.out.println("Max health: " + MAX_HEALTH);
+        System.out.println("relu: " + relu(this.health/MAX_HEALTH));
+        float healthBarWidth = this.getWidth() * relu(this.health / MAX_HEALTH);
+        if (healthBarWidth < 0) {
+            System.err.println("Health bar width is negative: " + healthBarWidth);
+            return;
+        }
+        float healthWidth = this.getWidth() * relu((float) this.health / MAX_HEALTH);
+        float healthHeight = this.getHeight()/20;
+        spriteBatch.draw(healthBarImage, this.getXPos(), this.getYPos() + (this.getHeight() * 1.02f), healthWidth, healthHeight);
     }
 
     private float relu(float value) {

--- a/core/src/com/league/game/screens/MainScreen.java
+++ b/core/src/com/league/game/screens/MainScreen.java
@@ -129,6 +129,6 @@ public class MainScreen extends ScreenAdapter {
         String username = usernameField.getText();
         String password = passwordField.getText();
         // TODO: handle registration
-//        HttpHandler.requestUserData(username, password, "register");
+        HttpHandler.requestUserData(username, password, "register");
     }
 }


### PR DESCRIPTION
This PR fixes the disappearing health bar after the character collides with an ability.  The health bar should drop and reduce in length, but it was disappearing completely.  A relu function was used to prevent negative values from displaying once the health dropped below zero.  The issue was that the health and max health were both Longs and produced a value between 0-1, this results in a 0 because of integer division.  The result was casted to a float to fix the issue.